### PR TITLE
Changes to log messages

### DIFF
--- a/utils/server/index.ts
+++ b/utils/server/index.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import { Message } from '@/types/chat';
 import { OpenAIModel } from '@/types/openai';
 
@@ -23,6 +25,46 @@ export class OpenAIError extends Error {
     this.code = code;
   }
 }
+
+
+const printLogLines = (
+  loggingObject: { 
+    messagesJSON: string; 
+    userName: string|null;
+    logID: string;
+    maxTokens: number;
+    temperature: number;
+    model: string|undefined;
+    page: number;
+    totalPages: number },
+    messages: {role: string; content: string}[],
+  result: String
+) => {
+  // Splunk supports up to 10,000 but because it's encoded JSON the quoted value may be up to 2x the unquoted
+  // Plus there's a field other fields in the logging object.
+  const maxCharacterCount = 5_000;
+  loggingObject.messagesJSON = JSON.stringify([
+      ...messages,
+      {
+        role: 'assistant',
+        content: result,
+      }
+    ]
+  )
+
+  const messagesLength = loggingObject.messagesJSON.length;
+  loggingObject.totalPages = Math.ceil(messagesLength / maxCharacterCount);
+
+  for (let i = 0; i < loggingObject.totalPages; i++) {
+    const start = i * maxCharacterCount;
+    const end = Math.min(start + maxCharacterCount, messagesLength);
+    loggingObject.page = i + 1;
+    console.log(JSON.stringify({
+      ...loggingObject,
+      messagesJSON: loggingObject.messagesJSON.substring(start, end)
+    }));
+  }
+};
 
 export const OpenAIStream = async (
   model: OpenAIModel,
@@ -91,10 +133,24 @@ export const OpenAIStream = async (
   const encoder = new TextEncoder();
   const decoder = new TextDecoder();
   const loggingObjectTempResult:string[] = [];
-  const loggingObject: { messages: any; userName: string|null; result: string } = { 
-    messages: body, 
-    userName: userName, 
-    result: ""
+  const loggingObject: { 
+      messagesJSON: string; 
+      userName: string|null;
+      logID: string;
+      maxTokens: number;
+      temperature: number;
+      model: string|undefined;
+      page: number;
+      totalPages: number } 
+    = { 
+    messagesJSON: "", 
+    userName: userName,
+    logID: uuidv4(),
+    maxTokens: body.max_tokens,
+    temperature: body.temperature,
+    model: body.model,
+    page: 1,
+    totalPages: 1
   };
 
   if (res.status !== 200) {
@@ -129,8 +185,7 @@ export const OpenAIStream = async (
             try {
               const json = JSON.parse(data);
               if (json.choices[0] && json.choices[0].finish_reason && json.choices[0].finish_reason != null) {
-                loggingObject.result = loggingObjectTempResult.join('');
-                console.log(JSON.stringify(loggingObject));
+                printLogLines(loggingObject, body.messages, loggingObjectTempResult.join(''))
                 controller.close();
                 return;
               }


### PR DESCRIPTION
New log message format with the body fields
being placed at the top level,

as well as messages now being messagesJSON
which is an encoded json string (yes double encoded)

This alongside the page and totalPages allows
the storage of messages over a specified limit
on some logging systems. For example splunk truncates messages over 10,000 characters in length.

Fixes [AI24-12](https://jira.epa.gov/browse/AI24-12)